### PR TITLE
 Added vertical spacing around the timestamp

### DIFF
--- a/src/components/NoteEditor.tsx
+++ b/src/components/NoteEditor.tsx
@@ -74,7 +74,7 @@ export function NoteEditor({ note, onUpdate, onDelete }: NoteEditorProps) {
         </div>
 
         {/* Timestamp Display */}
-        <div className="flex items-center gap-4 text-sm text-muted-foreground">
+        <div className="flex items-center gap-4 text-sm text-muted-foreground my-3">
           <div className="flex items-center gap-1.5">
             <Calendar className="w-4 h-4" />
             <span>Created: {formatTimestamp(note.createdAt)}</span>


### PR DESCRIPTION
What changed: I added a little vertical space around the timestamp row in 
src/components/NoteEditor.tsx

Why: The timestamps felt cramped between the title and the note content, especially when selecting text. The extra space makes it easier to read and keeps things from looking squished.