### PR TITLE
fix: default theme settings to system

### DIFF
--- a/src/components/theme/provider.tsx
+++ b/src/components/theme/provider.tsx
@@ -14,7 +14,7 @@ type ThemeProviderState = {
 };
 
 const initialState: ThemeProviderState = {
-  theme: "light",
+  theme: "system",
   setTheme: () => null,
 };
 


### PR DESCRIPTION
Default theme setting should always be system not light as user will have set his prefrence in the browser itself and to have a good app we should always prefer the user preference first