### PR TITLE
Added a new feature : Collapsible Keyboard Shortcuts

### DIFF
--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -2,7 +2,7 @@ import { useState, useEffect, useCallback } from "react";
 import { useNotes } from "@/hooks/useNotes";
 import { NotesSidebar } from "@/components/NotesSidebar";
 import { NoteEditor } from "@/components/NoteEditor";
-import { FileText, ArrowLeft } from "lucide-react";
+import { FileText, ArrowLeft, ChevronDown, ChevronUp } from "lucide-react";
 import { toast } from "sonner";
 
 const Index = () => {
@@ -10,6 +10,7 @@ const Index = () => {
     useNotes();
   const [activeNoteId, setActiveNoteId] = useState<string | null>(null);
   const [isMobile, setIsMobile] = useState(false);
+  const [isShortcutsOpen, setIsShortcutsOpen] = useState(true);
 
   useEffect(() => {
     const checkMobile = () => setIsMobile(window.innerWidth < 768);
@@ -152,17 +153,34 @@ const Index = () => {
           <main className="flex-1 overflow-hidden relative">
             {/* Keyboard Shortcuts Helper */}
             <div
-              className=" hidden md:block absolute bottom-4 right-4 bg-card border border-border rounded-lg p-3 shadow-lg text-xs z-10"
+              className=" hidden md:block absolute bottom-4 right-4 bg-card border border-border rounded-lg p-3 shadow-lg text-xs z-10 w-64"
               role="region"
               aria-labelledby="shortcuts-heading"
             >
               <div
                 id="shortcuts-heading"
-                className="font-semibold text-foreground mb-2 text-sm"
+                className={`font-semibold text-foreground text-sm flex justify-between items-center cursor-pointer ${
+                  isShortcutsOpen ? "mb-2" : "mb-0"
+                }`}
+                onClick={() => setIsShortcutsOpen(!isShortcutsOpen)}
+                aria-expanded={isShortcutsOpen}
+                aria-controls="shortcuts-content"
               >
-                Keyboard Shortcuts
+                <span>Keyboard Shortcuts</span>
+                {isShortcutsOpen ? (
+                  <ChevronDown className="h-4 w-4" />
+                ) : (
+                  <ChevronUp className="h-4 w-4" />
+                )}
               </div>
-              <div className="space-y-1 text-muted-foreground">
+              
+              <div
+                id="shortcuts-content"
+                className={`
+                  space-y-1 text-muted-foreground transition-all duration-500 ease-in-out overflow-hidden
+                  ${isShortcutsOpen ? 'max-h-96 opacity-100' : 'max-h-0 opacity-0'} 
+                `}
+              >
                 <div className="flex items-center justify-between gap-4">
                   <span>New note</span>
                   <kbd className="px-2 py-0.5 bg-muted rounded border border-border font-mono">
@@ -181,7 +199,6 @@ const Index = () => {
                     Cmd/Ctrl+D
                   </kbd>
                 </div>
-
                 <div className="flex items-center justify-between gap-4">
                   <span>Navigate</span>
                   <kbd className="px-2 py-0.5 bg-muted rounded border border-border font-mono">


### PR DESCRIPTION
# Title  :  [Fixed Issue #97] Added a new feature to make Keyboard Shortcuts Collapsible for ease of users.

## Screenshots for reference : 
### Before:
<img width="1919" height="922" alt="image" src="https://github.com/user-attachments/assets/0cc8047d-3cee-4567-adb6-ecbca3945ddf" />
### After:
Not Collapsed (Default) 
<img width="1919" height="921" alt="image" src="https://github.com/user-attachments/assets/787aff4e-4bd9-4b33-9b08-3e74ecc0284a" />
Collapsed
<img width="1910" height="920" alt="image" src="https://github.com/user-attachments/assets/e7c199aa-32bc-4a17-a2af-cd4d95507af2" />



