### PR TITLE
fix: show confirmation popup for delete shortcut and add toast

### DIFF
--- a/src/components/NoteCard.tsx
+++ b/src/components/NoteCard.tsx
@@ -96,7 +96,9 @@ export function NoteCard({ note, isActive, onClick, onDelete, onDuplicate }: Not
               <AlertDialogHeader>
                 <AlertDialogTitle>Delete Note</AlertDialogTitle>
                 <AlertDialogDescription>
-                  Are you sure you want to delete this note? This action cannot be undone.
+                  Are you sure you want to delete this note?
+                  <span className="font-semibold text-destructive"> "{note.title || 'Untitled Note'}"</span>?
+                  This action cannot be undone.
                 </AlertDialogDescription>
               </AlertDialogHeader>
               <AlertDialogFooter>

--- a/src/components/NoteCard.tsx
+++ b/src/components/NoteCard.tsx
@@ -37,9 +37,8 @@ export function NoteCard({ note, isActive, onClick, onDelete, onDuplicate, onTog
 
   return (
     <Card
-      className={`relative p-4 cursor-pointer transition-all justify-between flex hover:shadow-md ${
-        isActive ? 'ring-2 ring-primary bg-accent/5' : ''
-      }`}
+      className={`relative p-4 cursor-pointer transition-all justify-between flex hover:shadow-md ${isActive ? 'ring-2 ring-primary bg-accent/5' : ''
+        }`}
       onClick={onClick}
     >
       {onTogglePin && (
@@ -64,7 +63,7 @@ export function NoteCard({ note, isActive, onClick, onDelete, onDuplicate, onTog
         <h3 className="font-semibold text-foreground mb-1 truncate font-serif">
           {note.title || 'Untitled Note'}
         </h3>
-        
+
         {/* Tags Display - NEW UI */}
         {note.tags && note.tags.length > 0 && (
           <div className="flex flex-wrap gap-1 mb-2">
@@ -76,7 +75,7 @@ export function NoteCard({ note, isActive, onClick, onDelete, onDuplicate, onTog
             ))}
           </div>
         )}
-        
+
         {/* Timestamp Display */}
         <div className="flex flex-col gap-1 pt-2 border-t border-border/50">
           <div className="flex items-center gap-1.5 text-xs text-muted-foreground">

--- a/src/components/NoteEditor.tsx
+++ b/src/components/NoteEditor.tsx
@@ -163,8 +163,7 @@ export function NoteEditor({ note, onUpdate, onDelete }: NoteEditorProps) {
               <AlertDialogDescription>
                 Are you sure you want to delete this note
                 <span className="font-semibold text-destructive"> "{note.title || 'Untitled Note'}"</span>?
-                This action cannot be
-                undone.
+                This action cannot be undone.
               </AlertDialogDescription>
             </AlertDialogHeader>
             <AlertDialogFooter>

--- a/src/components/NoteEditor.tsx
+++ b/src/components/NoteEditor.tsx
@@ -161,7 +161,9 @@ export function NoteEditor({ note, onUpdate, onDelete }: NoteEditorProps) {
             <AlertDialogHeader>
               <AlertDialogTitle>Delete Note</AlertDialogTitle>
               <AlertDialogDescription>
-                Are you sure you want to delete this note? This action cannot be
+                Are you sure you want to delete this note
+                <span className="font-semibold text-destructive"> "{note.title || 'Untitled Note'}"</span>?
+                This action cannot be
                 undone.
               </AlertDialogDescription>
             </AlertDialogHeader>

--- a/src/components/NoteEditor.tsx
+++ b/src/components/NoteEditor.tsx
@@ -162,7 +162,7 @@ export function NoteEditor({ note, onUpdate, onDelete, onAddAttachments, onRemov
       await onRemoveAttachment(note.id, attachment.id);
     }
   };
-  
+
   const getSuggestions = (noteContent: string, currentTags: Tag[]): Tag[] => {
     if (!noteContent || currentTags.length >= 5) return [];
 
@@ -354,8 +354,8 @@ export function NoteEditor({ note, onUpdate, onDelete, onAddAttachments, onRemov
             {note.attachments.map(att => (
               <div key={att.id} className="flex items-center justify-between text-sm bg-muted/40 rounded px-2 py-1">
                 <div className="flex items-center gap-2 min-w-0">
-                  <span className="truncate max-w-[260px]" title={`${att.name} (${Math.round(att.size/1024)} KB)`}>{att.name}</span>
-                  <span className="text-muted-foreground text-xs">{Math.round(att.size/1024)} KB</span>
+                  <span className="truncate max-w-[260px]" title={`${att.name} (${Math.round(att.size / 1024)} KB)`}>{att.name}</span>
+                  <span className="text-muted-foreground text-xs">{Math.round(att.size / 1024)} KB</span>
                 </div>
                 <div className="flex items-center gap-2">
                   <Button size="sm" variant="ghost" onClick={() => handleDownload(att)}>Download</Button>

--- a/src/components/NotesSidebar.tsx
+++ b/src/components/NotesSidebar.tsx
@@ -29,7 +29,7 @@ export function NotesSidebar({
   onSelectNote,
   onCreateNote,
   onDelete,
-  onDuplicateNote, 
+  onDuplicateNote,
   onTogglePin,
   onOpenPinned,
 }: NotesSidebarProps) {
@@ -45,9 +45,9 @@ export function NotesSidebar({
 
       const titleMatch = note.title.toLowerCase().includes(query);
       const contentMatch = note.content.toLowerCase().includes(query);
-      
+
       // UPDATED: Filtering must work by searching for the tag label OR the tag emoji.
-      const tagMatch = (note.tags || []).some(tag => 
+      const tagMatch = (note.tags || []).some(tag =>
         tag.label.toLowerCase().includes(query) ||
         tag.emoji.includes(rawQuery) // Check the emoji directly against the search query
       );
@@ -89,7 +89,7 @@ export function NotesSidebar({
             >
               <Pin className="h-5 w-5" />
             </Button>
-            <ThemeToggle/>
+            <ThemeToggle />
             <Button
               disabled={notes.length === 0 || !activeNoteId}
               onClick={() => {
@@ -179,7 +179,7 @@ export function NotesSidebar({
                         note={note}
                         isActive={note.id === activeNoteId}
                         onClick={() => onSelectNote(note.id)}
-                        onDelete={onDelete || (() => {})}
+                        onDelete={onDelete || (() => { })}
                         onDuplicate={onDuplicateNote}
                         onTogglePin={onTogglePin}
                       />
@@ -199,7 +199,7 @@ export function NotesSidebar({
                       note={note}
                       isActive={note.id === activeNoteId}
                       onClick={() => onSelectNote(note.id)}
-                      onDelete={onDelete || (() => {})}
+                      onDelete={onDelete || (() => { })}
                       onDuplicate={onDuplicateNote}
                       onTogglePin={onTogglePin}
                     />

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -22,7 +22,7 @@ const Index = () => {
   const [isMobile, setIsMobile] = useState(false);
   const [isShortcutsOpen, setIsShortcutsOpen] = useState(true);
   const [pendingDeleteId, setPendingDeleteId] = useState<string | null>(null);
-  
+
   useEffect(() => {
     const checkMobile = () => setIsMobile(window.innerWidth < 768);
     checkMobile();
@@ -37,9 +37,15 @@ const Index = () => {
 
   const handleDeleteNote = (id: string) => {
     const deletedNote = notes.find(n => n.id === id);
+    // Determine next active note before deleting
+    let nextActiveNoteId: string | null = activeNoteId;
+    if (activeNoteId === id) {
+      const remainingNotes = notes.filter(n => n.id !== id);
+      nextActiveNoteId = remainingNotes.length > 0 ? remainingNotes[0].id : null;
+    }
     deleteNote(id);
     if (activeNoteId === id) {
-      setActiveNoteId(notes.length > 1 ? notes[0].id : null);
+      setActiveNoteId(nextActiveNoteId);
     }
     setPendingDeleteId(null);
     toast.success(`Note "${deletedNote?.title || 'Untitled Note'}" deleted`);
@@ -154,6 +160,9 @@ const Index = () => {
 
   const activeNote = notes.find((note) => note.id === activeNoteId);
 
+  const pendingDeleteNote = pendingDeleteId ? notes.find(n => n.id === pendingDeleteId) : null;
+  const pendingDeleteTitle = pendingDeleteNote?.title || 'Untitled Note';
+
   return (
     <div className="flex h-screen overflow-hidden bg-background">
       {/* Desktop Layout */}
@@ -176,9 +185,8 @@ const Index = () => {
             >
               <div
                 id="shortcuts-heading"
-                className={`font-semibold text-foreground text-sm flex justify-between items-center cursor-pointer ${
-                  isShortcutsOpen ? "mb-2" : "mb-0"
-                }`}
+                className={`font-semibold text-foreground text-sm flex justify-between items-center cursor-pointer ${isShortcutsOpen ? "mb-2" : "mb-0"
+                  }`}
                 onClick={() => setIsShortcutsOpen(!isShortcutsOpen)}
                 aria-expanded={isShortcutsOpen}
                 aria-controls="shortcuts-content"
@@ -190,7 +198,7 @@ const Index = () => {
                   <ChevronUp className="h-4 w-4" />
                 )}
               </div>
-              
+
               <div
                 id="shortcuts-content"
                 className={`
@@ -251,7 +259,7 @@ const Index = () => {
                   <AlertDialogTitle>Delete Note</AlertDialogTitle>
                   <AlertDialogDescription>
                     Are you sure you want to delete this note
-                    <span className="font-semibold text-destructive"> "{pendingDeleteId ? notes.find(n => n.id === pendingDeleteId)?.title || 'Untitled Note' : ''}"</span>?
+                    <span className="font-semibold text-destructive"> "{pendingDeleteTitle}"</span>?
                     This action cannot be undone.
                   </AlertDialogDescription>
                 </AlertDialogHeader>

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -242,32 +242,32 @@ const Index = () => {
               </div>
             )}
             {/* Delete confirmation dialog */}
-                        <AlertDialog
-                          open={!!pendingDeleteId}
-                          onOpenChange={(open) => !open && setPendingDeleteId(null)}
-                        >
-                          <AlertDialogContent>
-                            <AlertDialogHeader>
-                              <AlertDialogTitle>Delete Note</AlertDialogTitle>
-                              <AlertDialogDescription>
-                                Are you sure you want to delete this note
-                                <span className="font-semibold text-destructive"> "{pendingDeleteId ? notes.find(n => n.id === pendingDeleteId)?.title || 'Untitled Note' : ''}"</span>?
-                                This action cannot be undone.
-                              </AlertDialogDescription>
-                            </AlertDialogHeader>
-                            <AlertDialogFooter>
-                              <AlertDialogCancel onClick={() => setPendingDeleteId(null)}>
-                                Cancel
-                              </AlertDialogCancel>
-                              <AlertDialogAction
-                                onClick={() => handleDeleteNote(pendingDeleteId!)}
-                                className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
-                              >
-                                Delete
-                              </AlertDialogAction>
-                            </AlertDialogFooter>
-                          </AlertDialogContent>
-                        </AlertDialog>
+            <AlertDialog
+              open={!!pendingDeleteId}
+              onOpenChange={(open) => !open && setPendingDeleteId(null)}
+            >
+              <AlertDialogContent>
+                <AlertDialogHeader>
+                  <AlertDialogTitle>Delete Note</AlertDialogTitle>
+                  <AlertDialogDescription>
+                    Are you sure you want to delete this note
+                    <span className="font-semibold text-destructive"> "{pendingDeleteId ? notes.find(n => n.id === pendingDeleteId)?.title || 'Untitled Note' : ''}"</span>?
+                    This action cannot be undone.
+                  </AlertDialogDescription>
+                </AlertDialogHeader>
+                <AlertDialogFooter>
+                  <AlertDialogCancel onClick={() => setPendingDeleteId(null)}>
+                    Cancel
+                  </AlertDialogCancel>
+                  <AlertDialogAction
+                    onClick={() => handleDeleteNote(pendingDeleteId!)}
+                    className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+                  >
+                    Delete
+                  </AlertDialogAction>
+                </AlertDialogFooter>
+              </AlertDialogContent>
+            </AlertDialog>
           </main>
         </>
       )}


### PR DESCRIPTION
Fixes #99
- Refactors delete shortcut (Ctrl/Cmd+D) to show a confirmation dialog before deleting a note, matching the UI behavior of the delete button.
- Adds toast notifications for note duplication and deletion, including the note title for clarity.